### PR TITLE
Fix some hidden bugs

### DIFF
--- a/matlab/computeArealTerms.m
+++ b/matlab/computeArealTerms.m
@@ -66,6 +66,10 @@ if computeDerivatives == 1
 		dareal_dphi(cI) = dareal_dphi(cI) + aTerms(loc)*ncas(:, loc)'*dp2_dphi;
 		dareal_dtheta(cI) = dareal_dtheta(cI) + aTerms(loc)*ncas(:, loc)'*dp2_dtheta;
 	end
+
+    dareal_dphi = dareal_dphi * 0.5;
+    dareal_dtheta = dareal_dtheta * 0.5;
+
 end
 
 %% OLD, non-vectorized method

--- a/matlab/funcnorm.m
+++ b/matlab/funcnorm.m
@@ -354,7 +354,7 @@ function warps = funcnorm(subjects, hems, varargin)
             displayLogItem(['Performing alignment of subject #', num2str(subjNum), ' (', subj, ') on pass #0'], logFile);
             displayLogItem(['A log of this alignment will be saved to ', alignLogFile], logFile);
             
-            warp = funcnorm_register(atlasTS, TS, coords, zeros(3, numNodes, opsDataType), regularization, maxResolution, alignLogFile);
+            warp = funcnorm_register(TS, atlasTS, coords, zeros(3, numNodes, opsDataType), regularization, maxResolution, alignLogFile);
             displayLogItem(['Completed alignment of subject #', num2str(subjNum), ' (', subj, ') on pass #0'], logFile);
 
             % Now we need to output the warp file


### PR DESCRIPTION
- a bug with the gradient of areal (folding) terms.
- a bug that would align `atlasTS` to `TS` in the 0th pass of `funcnorm`, which should be vice versa.

See the commit messages for the details.
